### PR TITLE
Add zooming in Helicopter View with mouse scroll wheel

### DIFF
--- a/F-4S-set.xml
+++ b/F-4S-set.xml
@@ -37,6 +37,15 @@ See LICENSE file for the GPL version 2 text.
 		</rating>
 		<status>Alpha</status>
 
+        <current-view>
+            <z-offset-dec-step type="double">0.0</z-offset-dec-step>
+            <z-offset-inc-step type="double">0.0</z-offset-inc-step>
+            <can-change-z-offset type="bool">false</can-change-z-offset>
+
+            <z-offset-min-m type="float">15.0</z-offset-min-m>
+            <z-offset-max-m type="float">300.0</z-offset-max-m>
+        </current-view>
+
 		<startup>
 			<splash-texture>Aircraft/F-4X/splash-1.png</splash-texture>
 			<splash-texture>Aircraft/F-4X/thumbnail.jpg</splash-texture>
@@ -61,6 +70,12 @@ See LICENSE file for the GPL version 2 text.
 			<enable3d n="0">false</enable3d>
 			<enable3d n="1">false</enable3d>
 		</hud>
+
+        <systems>
+            <property-rule n="100">
+                <path>Systems/mouse-zoom.xml</path>
+            </property-rule>
+        </systems>
 
 		<view>
 			<name>Cockpit View</name>
@@ -110,6 +125,10 @@ See LICENSE file for the GPL version 2 text.
 			</hydromech>
 		</jsbsim>
 	</fdm>
+
+    <input>
+        <mice include="Systems/mice.xml"/>
+    </input>
 
 	<sound>
 		<path type="string">Aircraft/F-4X/Audio/audio.xml</path>

--- a/Systems/mice.xml
+++ b/Systems/mice.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2015 onox
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<PropertyList>
+
+    <mouse n="0">
+
+        <mode n="0">
+            <button n="3">
+                <binding n="0">
+                    <script></script>
+                </binding>
+                <binding n="1">
+                    <condition>
+                        <property>/sim/current-view/can-change-z-offset</property>
+                    </condition>
+                    <command>nasal</command>
+                    <script>
+                        var distance = getprop("/sim/current-view/z-offset-m");
+                        var multiple = getprop("/sim/current-view/z-offset-inc-step");
+                        var min_dist = getprop("/sim/current-view/z-offset-min-m");
+
+                        # Round distance to a multiple of the step
+                        distance = math.round(std.min(-min_dist, distance + multiple) / multiple) * multiple;
+                        setprop("/sim/current-view/z-offset-m", distance);
+
+                        gui.popupTip(sprintf("%d meter", abs(getprop("/sim/current-view/z-offset-m"))));
+                    </script>
+                </binding>
+            </button>
+
+            <button n="4">
+                <binding n="0">
+                    <script></script>
+                </binding>
+                <binding n="1">
+                    <condition>
+                        <property>/sim/current-view/can-change-z-offset</property>
+                    </condition>
+                    <command>nasal</command>
+                    <script>
+                        var distance = getprop("/sim/current-view/z-offset-m");
+                        var multiple = getprop("/sim/current-view/z-offset-dec-step");
+                        var max_dist = getprop("/sim/current-view/z-offset-max-m");
+
+                        # Round distance to a multiple of the step
+                        distance = math.round(std.max(-max_dist, distance + multiple) / multiple) * multiple;
+                        setprop("/sim/current-view/z-offset-m", distance);
+
+                        gui.popupTip(sprintf("%d meter", abs(getprop("/sim/current-view/z-offset-m"))));
+                    </script>
+                </binding>
+            </button>
+        </mode>
+
+    </mouse>
+
+</PropertyList>

--- a/Systems/mouse-zoom.xml
+++ b/Systems/mouse-zoom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2015 onox
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<PropertyList>
+
+    <!-- ================================================================== -->
+    <!-- Scroll Wheel Zooming                                               -->
+    <!-- ================================================================== -->
+
+    <logic>
+        <name>View Zoom Enabled</name>
+        <input>
+            <and>
+                <equals>
+                    <property>/sim/current-view/type</property>
+                    <value>lookat</value>
+                </equals>
+                <not-equals>
+                    <property>/sim/current-view/name</property>
+                    <value>Tower View</value>
+                </not-equals>
+                <not-equals>
+                    <property>/sim/current-view/name</property>
+                    <value>Fly-By View</value>
+                </not-equals>
+                <not-equals>
+                    <property>/sim/current-view/name</property>
+                    <value>Chase View</value>
+                </not-equals>
+                <not-equals>
+                    <property>/sim/current-view/name</property>
+                    <value>Chase View Without Yaw</value>
+                </not-equals>
+                <not-equals>
+                    <property>/sim/current-view/name</property>
+                    <value>Walk View</value>
+                </not-equals>
+            </and>
+        </input>
+        <output>
+            <property>/sim/current-view/can-change-z-offset</property>
+        </output>
+    </logic>
+
+    <filter>
+        <name>View Zoom Decrease Step</name>
+        <type>gain</type>
+        <input>
+            <condition>
+                <less-than-equals>
+                    <property>/sim/current-view/z-offset-m</property>
+                    <value>-100.0</value>
+                </less-than-equals>
+            </condition>
+            <value>-25.0</value>
+        </input>
+        <input>
+            <condition>
+                <less-than-equals>
+                    <property>/sim/current-view/z-offset-m</property>
+                    <value>-50.0</value>
+                </less-than-equals>
+            </condition>
+            <value>-10.0</value>
+        </input>
+        <input>
+            <value>-5.0</value>
+        </input>
+        <output>
+            <property>/sim/current-view/z-offset-dec-step</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>View Zoom Increase Step</name>
+        <type>gain</type>
+        <input>
+            <condition>
+                <less-than>
+                    <property>/sim/current-view/z-offset-m</property>
+                    <value>-100.0</value>
+                </less-than>
+            </condition>
+            <value>25.0</value>
+        </input>
+        <input>
+            <condition>
+                <less-than>
+                    <property>/sim/current-view/z-offset-m</property>
+                    <value>-50.0</value>
+                </less-than>
+            </condition>
+            <value>10.0</value>
+        </input>
+        <input>
+            <value>5.0</value>
+        </input>
+        <output>
+            <property>/sim/current-view/z-offset-inc-step</property>
+        </output>
+    </filter>
+
+</PropertyList>


### PR DESCRIPTION
Fixes #5 

The minimum distance is set to 15 meter and the maximum to 300 meter. Using the mouse scroll wheel changes the distance instead of the FOV. Only enabled for certain views like the Helicopter View in which this feature works reliable.